### PR TITLE
LIBMOBILE-1276 - Bump up analytics-kotlin version to latest. 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ version = getVersionName()
 
 plugins {
     // Apply the org.jetbrains.kotlin.jvm Plugin to add support for Kotlin.
-    id("org.jetbrains.kotlin.jvm") version "1.6.0"
+    id("org.jetbrains.kotlin.jvm") version "1.8.0"
 
     // Apply the java-library plugin for API and implementation separation.
     `java-library`
@@ -22,8 +22,8 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0")
-        classpath("org.jetbrains.kotlin:kotlin-serialization:1.6.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.0")
+        classpath("org.jetbrains.kotlin:kotlin-serialization:1.8.0")
         classpath("com.android.tools.build:gradle:7.0.4")
         classpath("com.bugsnag:bugsnag-android-gradle-plugin:7.4.1")
     }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -10,7 +10,7 @@ val VERSION_NAME: String by project
 
 android {
     compileSdk = 33
-    buildToolsVersion = "31.0.0"
+    buildToolsVersion = "33.0.1"
 
     defaultConfig {
         multiDexEnabled = true
@@ -42,9 +42,9 @@ android {
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.2")
 
-    implementation("com.segment.analytics.kotlin:android:1.6.2")
+    implementation("com.segment.analytics.kotlin:android:1.10.3")
     implementation("androidx.multidex:multidex:2.0.1")
-    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.core:core-ktx:1.8.0")
 
     implementation("androidx.lifecycle:lifecycle-process:2.5.1")
     implementation("androidx.lifecycle:lifecycle-common-java8:2.5.1")
@@ -52,13 +52,13 @@ dependencies {
 
 // Partner Dependencies
 dependencies {
-    implementation("com.bugsnag:bugsnag-android:5.28.4")
+    implementation("com.bugsnag:bugsnag-android:5.29.0")
 }
 
 // Test Dependencies
 dependencies {
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4")
     testImplementation("io.mockk:mockk:1.12.4")
 
     // Add Roboelectric dependencies.


### PR DESCRIPTION
LIBMOBILE-1276
- upgraded Analytics version from 1.6.2 to 1.10.3
- upgraded target and compile SDK version from 31 to 33
- upgraded kotlin core to 1.8.0
- upgraded Bugsnag sdk from 5.28.4 to 5.29.0